### PR TITLE
Updating tag names and other QOL improvements

### DIFF
--- a/inovelli-matter-switch-tap-sequences.yaml
+++ b/inovelli-matter-switch-tap-sequences.yaml
@@ -9,7 +9,7 @@ blueprint:
       - Bind the Inovelli Switches Light Entity to Target Light(s)
 
     Light bindings will sync both the on/off state and brightness of the Inovelli Switches Light Entity to other light entity(ies). When using bindings there will be some lag, thus it is recommended you increase your dimming speed. 
-    
+
     ### The following settings are recommended to help make the transitions more fluid:
 
       - Slow down the dimming speed on the Inovelli Switch to account for lag
@@ -19,7 +19,7 @@ blueprint:
 
     Please note, when Minimum Brightness is > 1, the automation will ensure the Target Light never falls below that value, with an adjusted linear scale 
     between the minimum value and 100%. Because of this, the brightness value for each light may not always match.
-    
+
     Supported Models:
       - VTM31-SN
       - VTM35-SN
@@ -32,52 +32,53 @@ blueprint:
   input:
     entity_inputs:
       name: Inovelli Switch Entities
-      description: 'Example: the Event Entity for Config can be found here: Settings > Devices & services > Matter > # Devices > *Select
-        your device* > Events > Up > Settings Icon > entity_id'
-      icon: mdi:devices  
+      description:
+        "Example: the Event Entity for Config can be found here: Settings > Devices & services > Matter > # Devices > *Select
+        your device* > Events > Up > Settings Icon > entity_id"
+      icon: mdi:devices
       input:
-        entity_config:
+        config_event:
           name: Event Entity for Config
-          description: "The event entity for Config taps"
+          description: The event entity for Config taps
           selector:
             entity:
               filter:
-              - integration: matter
-                domain: event
-                device_class: button
+                - integration: matter
+                  domain: event
+                  device_class: button
               multiple: false
-        entity_down:
+        down_event:
           name: Event Entity for Down
           description: The Event Entity for Down taps
           selector:
             entity:
               filter:
-              - integration: matter
-                domain: event
-                device_class: button
+                - integration: matter
+                  domain: event
+                  device_class: button
               multiple: false
-        entity_up:
+        up_event:
           name: Event Entity for Up
           description: The Event Entity for Up taps*
           selector:
             entity:
               filter:
-              - integration: matter
-                domain: event
-                device_class: button
+                - integration: matter
+                  domain: event
+                  device_class: button
               multiple: false
-        entity_light:
+        switch_light:
           name: Light Entity
           description: The light entity for the Inovelli Switch
           selector:
             entity:
               filter:
-              - domain: light
-                integration: matter
+                - domain: light
+                  integration: matter
               multiple: false
     up_inputs:
       name: Up
-      icon: mdi:cog
+      icon: mdi:arrow-up-thick
       input:
         up1:
           name: Single
@@ -123,7 +124,7 @@ blueprint:
             action: {}
     down_inputs:
       name: Down
-      icon: mdi:cog
+      icon: mdi:arrow-down-thick
       input:
         down1:
           name: Single
@@ -169,7 +170,7 @@ blueprint:
             action: {}
     config_inputs:
       name: Config
-      icon: mdi:cog
+      icon: mdi:button-pointer
       input:
         config1:
           name: Single
@@ -217,280 +218,287 @@ blueprint:
       name: Light Bindings
       icon: mdi:sync
       input:
-        target_light:
+        default_light:
           name: Target Light(s)
           description: Select the light entity that will be synced to the Inovelli Switch
           default: []
           selector:
             entity:
               filter:
-              - domain:
-                - light
-              multiple: true
+                - domain: light
+              multiple: false
         min_brightness:
           name: Minimum Brightness
           description: Set the minimum brightness for the target light(s), as a percentage (1-100).
           default: 1
           selector:
             number:
-              min: 1
-              max: 100
+              min: 1.0
+              max: 100.0
+              step: 1.0
+              mode: slider
         reverse_sync:
           name: Reverse Sync
           description: If the target light is toggled on/off by an outside source, the Inovelli Switch will sync.
           default: false
           selector:
             boolean: {}
-  source_url: https://github.com/gravityrebel/inovelli-matter-switch-tap-sequences/blob/improved-filtering/inovelli-matter-switch-tap-sequences.yaml
+  source_url: https://github.com/gravityrebel/inovelli-matter-switch-tap-sequences/blob/dev/inovelli-matter-switch-tap-sequences.yaml
 mode: queued
 max_exceeded: silent
 variables:
-  controlLight: !input entity_light
+  controlLight: !input switch_light
   reverseSync: !input reverse_sync
 trigger:
   - platform: state
-    entity_id: !input entity_up
+    entity_id: !input up_event
     not_from:
-    - unknown
-    - unavailable
+      - unknown
+      - unavailable
     id: up
   - platform: state
-    entity_id: !input entity_down
+    entity_id: !input down_event
     not_from:
-    - unknown
-    - unavailable
+      - unknown
+      - unavailable
     id: down
   - platform: state
-    entity_id: !input entity_config
+    entity_id: !input config_event
     not_from:
-    - unknown
-    - unavailable
+      - unknown
+      - unavailable
     id: config
   - platform: state
-    entity_id: !input entity_light
+    entity_id: !input switch_light
     id: turnOn
     from: "off"
     to: "on"
   - platform: state
-    entity_id: !input entity_light
+    entity_id: !input switch_light
     id: turnOff
     from: "on"
     to: "off"
   - platform: state
-    entity_id: !input target_light
+    entity_id: !input default_light
     id: reverseSyncOff
     from: "on"
     to: "off"
   - platform: state
-    entity_id: !input target_light
+    entity_id: !input default_light
     id: reverseSyncOn
     from: "off"
     to: "on"
   - platform: state
-    entity_id: !input entity_light
+    entity_id: !input switch_light
     attribute: brightness
     id: turnOn
 condition: []
 action:
-- choose:
-  - conditions:
-    - condition: trigger
-      id:
-      - up
-    sequence:
-    - choose:
+  - choose:
       - conditions:
-        - condition: state
-          entity_id: !input entity_up
-          attribute: event_type
-          state: multi_press_1
-        sequence: !input up1
-      - conditions:
-        - condition: state
-          entity_id: !input entity_up
-          attribute: event_type
-          state: multi_press_2
-        sequence: !input up2
-      - conditions:
-        - condition: state
-          entity_id: !input entity_up
-          attribute: event_type
-          state: multi_press_3
-        sequence: !input up3
-      - conditions:
-        - condition: state
-          entity_id: !input entity_up
-          attribute: event_type
-          state: multi_press_4
-        sequence: !input up4
-      - conditions:
-        - condition: state
-          entity_id: !input entity_up
-          attribute: event_type
-          state: multi_press_5
-        sequence: !input up5
-      - conditions:
-        - condition: state
-          entity_id: !input entity_up
-          attribute: event_type
-          state: long_press
-        sequence: !input upHeld
-      - conditions:
-        - condition: state
-          entity_id: !input entity_up
-          attribute: event_type
-          state: long_release
-        sequence: !input upReleased
-  - conditions:
-    - condition: trigger
-      id:
-      - down
-    sequence:
-    - choose:
-      - conditions:
-        - condition: state
-          entity_id: !input entity_down
-          attribute: event_type
-          state: multi_press_1
-        sequence: !input down1
-      - conditions:
-        - condition: state
-          entity_id: !input entity_down
-          attribute: event_type
-          state: multi_press_2
-        sequence: !input down2
-      - conditions:
-        - condition: state
-          entity_id: !input entity_down
-          attribute: event_type
-          state: multi_press_3
-        sequence: !input down3
-      - conditions:
-        - condition: state
-          entity_id: !input entity_down
-          attribute: event_type
-          state: multi_press_4
-        sequence: !input down4
-      - conditions:
-        - condition: state
-          entity_id: !input entity_down
-          attribute: event_type
-          state: multi_press_5
-        sequence: !input down5
-      - conditions:
-        - condition: state
-          entity_id: !input entity_down
-          attribute: event_type
-          state: long_press
-        sequence: !input downHeld
-      - conditions:
-        - condition: state
-          entity_id: !input entity_down
-          attribute: event_type
-          state: long_release
-        sequence: !input downReleased
-  - conditions:
-    - condition: trigger
-      id:
-      - config
-    sequence:
-    - choose:
-      - conditions:
-        - condition: state
-          entity_id: !input entity_config
-          attribute: event_type
-          state: multi_press_1
-        sequence: !input config1
-      - conditions:
-        - condition: state
-          entity_id: !input entity_config
-          attribute: event_type
-          state: multi_press_2
-        sequence: !input config2
-      - conditions:
-        - condition: state
-          entity_id: !input entity_config
-          attribute: event_type
-          state: multi_press_3
-        sequence: !input config3
-      - conditions:
-        - condition: state
-          entity_id: !input entity_config
-          attribute: event_type
-          state: multi_press_4
-        sequence: !input config4
-      - conditions:
-        - condition: state
-          entity_id: !input entity_config
-          attribute: event_type
-          state: multi_press_5
-        sequence: !input config5
-      - conditions:
-        - condition: state
-          entity_id: !input entity_config
-          attribute: event_type
-          state: long_press
-        sequence: !input configHeld
-      - conditions:
-        - condition: state
-          entity_id: !input entity_config
-          attribute: event_type
-          state: long_release
-        sequence: !input configReleased
-  - conditions:
-      - condition: trigger
-        id:
-          - turnOff
-    sequence:
-    - variables:
-        controlLight: !input entity_light
-    - action: light.turn_off
-      metadata: {}
-      data: {}
-      target:
-        entity_id: !input target_light
-  - conditions:
-      - condition: trigger
-        id:
-          - reverseSyncOff
-          - reverseSyncOn
-    sequence:
-      - if: '{{ reverseSync }}'
-        then:
+          - condition: trigger
+            id:
+              - up
+        sequence:
           - choose:
               - conditions:
-                  - condition: trigger
-                    id:
-                      - reverseSyncOff
-                sequence:
-                - action: light.turn_off
-                  target:
-                    entity_id: !input entity_light
-                  data: {}
+                  - condition: state
+                    entity_id: !input up_event
+                    attribute: event_type
+                    state: multi_press_1
+                sequence: !input up1
               - conditions:
-                  - condition: trigger
-                    id:
-                      - reverseSyncOn
-                sequence:
-                - action: light.turn_on
-                  target:
-                    entity_id: !input entity_light
-                  data: {}
-  - conditions:
-      - condition: trigger
-        id:
-          - turnOn
-    sequence:
-    - variables:
-        controlLight: !input entity_light
-        controlLightBrightness: |
-          {{ (state_attr(controlLight, 'brightness') / 2.55) }}
-        minBrightness: !input min_brightness
-        brightnessValue: |
-          {{ (((100 - minBrightness) / 100 ) * controlLightBrightness + minBrightness ) | round(0) }}
-    - action: light.turn_on
-      metadata: {}
-      data:
-        brightness_pct: '{{ brightnessValue }}'
-      target:
-        entity_id: !input target_light
+                  - condition: state
+                    entity_id: !input up_event
+                    attribute: event_type
+                    state: multi_press_2
+                sequence: !input up2
+              - conditions:
+                  - condition: state
+                    entity_id: !input up_event
+                    attribute: event_type
+                    state: multi_press_3
+                sequence: !input up3
+              - conditions:
+                  - condition: state
+                    entity_id: !input up_event
+                    attribute: event_type
+                    state: multi_press_4
+                sequence: !input up4
+              - conditions:
+                  - condition: state
+                    entity_id: !input up_event
+                    attribute: event_type
+                    state: multi_press_5
+                sequence: !input up5
+              - conditions:
+                  - condition: state
+                    entity_id: !input up_event
+                    attribute: event_type
+                    state: long_press
+                sequence: !input upHeld
+              - conditions:
+                  - condition: state
+                    entity_id: !input up_event
+                    attribute: event_type
+                    state: long_release
+                sequence: !input upReleased
+      - conditions:
+          - condition: trigger
+            id:
+              - down
+        sequence:
+          - choose:
+              - conditions:
+                  - condition: state
+                    entity_id: !input down_event
+                    attribute: event_type
+                    state: multi_press_1
+                sequence: !input down1
+              - conditions:
+                  - condition: state
+                    entity_id: !input down_event
+                    attribute: event_type
+                    state: multi_press_2
+                sequence: !input down2
+              - conditions:
+                  - condition: state
+                    entity_id: !input down_event
+                    attribute: event_type
+                    state: multi_press_3
+                sequence: !input down3
+              - conditions:
+                  - condition: state
+                    entity_id: !input down_event
+                    attribute: event_type
+                    state: multi_press_4
+                sequence: !input down4
+              - conditions:
+                  - condition: state
+                    entity_id: !input down_event
+                    attribute: event_type
+                    state: multi_press_5
+                sequence: !input down5
+              - conditions:
+                  - condition: state
+                    entity_id: !input down_event
+                    attribute: event_type
+                    state: long_press
+                sequence: !input downHeld
+              - conditions:
+                  - condition: state
+                    entity_id: !input down_event
+                    attribute: event_type
+                    state: long_release
+                sequence: !input downReleased
+      - conditions:
+          - condition: trigger
+            id:
+              - config
+        sequence:
+          - choose:
+              - conditions:
+                  - condition: state
+                    entity_id: !input config_event
+                    attribute: event_type
+                    state: multi_press_1
+                sequence: !input config1
+              - conditions:
+                  - condition: state
+                    entity_id: !input config_event
+                    attribute: event_type
+                    state: multi_press_2
+                sequence: !input config2
+              - conditions:
+                  - condition: state
+                    entity_id: !input config_event
+                    attribute: event_type
+                    state: multi_press_3
+                sequence: !input config3
+              - conditions:
+                  - condition: state
+                    entity_id: !input config_event
+                    attribute: event_type
+                    state: multi_press_4
+                sequence: !input config4
+              - conditions:
+                  - condition: state
+                    entity_id: !input config_event
+                    attribute: event_type
+                    state: multi_press_5
+                sequence: !input config5
+              - conditions:
+                  - condition: state
+                    entity_id: !input config_event
+                    attribute: event_type
+                    state: long_press
+                sequence: !input configHeld
+              - conditions:
+                  - condition: state
+                    entity_id: !input config_event
+                    attribute: event_type
+                    state: long_release
+                sequence: !input configReleased
+      - conditions:
+          - condition: trigger
+            id:
+              - turnOff
+        sequence:
+          - variables:
+              controlLight: !input switch_light
+          - action: light.turn_off
+            metadata: {}
+            data: {}
+            target:
+              entity_id: !input default_light
+      - conditions:
+          - condition: trigger
+            id:
+              - reverseSyncOff
+              - reverseSyncOn
+        sequence:
+          - if: "{{ reverseSync }}"
+            then:
+              - choose:
+                  - conditions:
+                      - condition: trigger
+                        id:
+                          - reverseSyncOff
+                    sequence:
+                      - action: light.turn_off
+                        target:
+                          entity_id: !input switch_light
+                        data: {}
+                  - conditions:
+                      - condition: trigger
+                        id:
+                          - reverseSyncOn
+                    sequence:
+                      - action: light.turn_on
+                        target:
+                          entity_id: !input switch_light
+                        data: {}
+      - conditions:
+          - condition: trigger
+            id:
+              - turnOn
+        sequence:
+          - variables:
+              controlLight: !input switch_light
+              controlLightBrightness:
+                "{{ (state_attr(controlLight, 'brightness') / 2.55)
+                }}
+
+                "
+              minBrightness: !input min_brightness
+              brightnessValue:
+                "{{ (((100 - minBrightness) / 100 ) * controlLightBrightness
+                + minBrightness ) | round(0) }}
+
+                "
+          - action: light.turn_on
+            metadata: {}
+            data:
+              brightness_pct: "{{ brightnessValue }}"
+            target:
+              entity_id: !input default_light

--- a/inovelli-matter-switch-tap-sequences.yaml
+++ b/inovelli-matter-switch-tap-sequences.yaml
@@ -29,7 +29,7 @@ blueprint:
   author: jay-kub
   homeassistant:
     min_version: 2024.8.0
-  input: #This section defines the inputs that appear visually for the user.
+  input: # This section defines the inputs that appear visually for the user.
     entity_inputs: # This section is for entities related to the switch itself.
       name: Inovelli Switch Entities
       description:
@@ -80,43 +80,43 @@ blueprint:
       name: Up
       icon: mdi:arrow-up-thick
       input:
-        up1:
+        up1Action:
           name: Single
           description: When Up is pressed 1 time
           default: []
           selector:
             action: {}
-        up2:
+        up2Action:
           name: Double
           description: When Up is pressed 2 times
           default: []
           selector:
             action: {}
-        up3:
+        up3Action:
           name: Triple
           description: When Up is pressed 3 times
           default: []
           selector:
             action: {}
-        up4:
+        up4Action:
           name: Quadruple
           description: When Up is pressed 4 times
           default: []
           selector:
             action: {}
-        up5:
+        up5Action:
           name: Quintuple
           description: When Up is pressed 5 times
           default: []
           selector:
             action: {}
-        upHeld:
+        upHeldAction:
           name: Up Held
           description: When Up is held
           default: []
           selector:
             action: {}
-        upReleased:
+        upReleasedAction:
           name: Up Released
           description: When Up is released
           default: []
@@ -126,43 +126,43 @@ blueprint:
       name: Down
       icon: mdi:arrow-down-thick
       input:
-        down1:
+        down1Action:
           name: Single
           description: When Down is pressed 1 time
           default: []
           selector:
             action: {}
-        down2:
+        down2Action:
           name: Double
           description: When Down is pressed 2 times
           default: []
           selector:
             action: {}
-        down3:
+        down3Action:
           name: Triple
           description: When Down is pressed 3 times
           default: []
           selector:
             action: {}
-        down4:
+        down4Action:
           name: Quadruple
           description: When Down is pressed 4 times
           default: []
           selector:
             action: {}
-        down5:
+        down5Action:
           name: Quintuple
           description: When Down is pressed 5 times
           default: []
           selector:
             action: {}
-        downHeld:
+        downHeldAction:
           name: Down Held
           description: When Down is held
           default: []
           selector:
             action: {}
-        downReleased:
+        downReleasedAction:
           name: Down Released
           description: When Down is released
           default: []
@@ -172,43 +172,43 @@ blueprint:
       name: Config
       icon: mdi:button-pointer
       input:
-        config1:
+        config1Action:
           name: Single
           description: When Config is pressed 1 time
           default: []
           selector:
             action: {}
-        config2:
+        config2Action:
           name: Double
           description: When Config is pressed 2 times
           default: []
           selector:
             action: {}
-        config3:
+        config3Action:
           name: Triple
           description: When Config is pressed 3 times
           default: []
           selector:
             action: {}
-        config4:
+        config4Action:
           name: Quadruple
           description: When Config is pressed 4 times
           default: []
           selector:
             action: {}
-        config5:
+        config5Action:
           name: Quintuple
           description: When Config is pressed 5 times
           default: []
           selector:
             action: {}
-        configHeld:
+        configHeldAction:
           name: Config Held
           description: When Config is held
           default: []
           selector:
             action: {}
-        configReleased:
+        configReleasedAction:
           name: Config Released
           description: When Config is released
           default: []
@@ -237,8 +237,8 @@ blueprint:
               max: 100.0
               step: 1.0
               mode: slider
-        reverse_sync:
-          name: Reverse Sync
+        matchSwitchLightWithDefault:
+          name: Match Switch Light with Default
           description: If the target light is toggled on/off by an outside source, the Inovelli Switch will sync.
           default: false
           selector:
@@ -250,8 +250,8 @@ max_exceeded: silent
 
 # Start Automation definition
 variables: # Set up variables to be used in templates.
-  controlLight: !input switch_light
-  reverseSync: !input reverse_sync
+  switchLight: !input switch_light
+  shouldSyncDefaultLightToSwitch: !input matchSwitchLightWithDefault
 
 trigger: # Defines the triggers the automation will use to run. Nominally the events from the switch.
   - id: up
@@ -318,91 +318,91 @@ action:
                     entity_id: !input up_event
                     attribute: event_type
                     state: multi_press_1
-                sequence: !input up1
+                sequence: !input up1Action
               - conditions:
                   - condition: state
                     entity_id: !input up_event
                     attribute: event_type
                     state: multi_press_2
-                sequence: !input up2
+                sequence: !input up2Action
               - conditions:
                   - condition: state
                     entity_id: !input up_event
                     attribute: event_type
                     state: multi_press_3
-                sequence: !input up3
+                sequence: !input up3Action
               - conditions:
                   - condition: state
                     entity_id: !input up_event
                     attribute: event_type
                     state: multi_press_4
-                sequence: !input up4
+                sequence: !input up4Action
               - conditions:
                   - condition: state
                     entity_id: !input up_event
                     attribute: event_type
                     state: multi_press_5
-                sequence: !input up5
+                sequence: !input up5Action
               - conditions:
                   - condition: state
                     entity_id: !input up_event
                     attribute: event_type
                     state: long_press
-                sequence: !input upHeld
+                sequence: !input upHeldAction
               - conditions:
                   - condition: state
                     entity_id: !input up_event
                     attribute: event_type
                     state: long_release
-                sequence: !input upReleased
+                sequence: !input upReleasedAction
       
       - conditions: # When the down event is the trigger.
           - condition: trigger
             id: down
         sequence:
-          - choose: #Check the state of the down event based on number of clicks
+          - choose: # Check the state of the down event based on number of clicks
               - conditions:
                   - condition: state
                     entity_id: !input down_event
                     attribute: event_type
                     state: multi_press_1
-                sequence: !input down1
+                sequence: !input down1Action
               - conditions:
                   - condition: state
                     entity_id: !input down_event
                     attribute: event_type
                     state: multi_press_2
-                sequence: !input down2
+                sequence: !input down2Action
               - conditions:
                   - condition: state
                     entity_id: !input down_event
                     attribute: event_type
                     state: multi_press_3
-                sequence: !input down3
+                sequence: !input down3Action
               - conditions:
                   - condition: state
                     entity_id: !input down_event
                     attribute: event_type
                     state: multi_press_4
-                sequence: !input down4
+                sequence: !input down4Action
               - conditions:
                   - condition: state
                     entity_id: !input down_event
                     attribute: event_type
                     state: multi_press_5
-                sequence: !input down5
+                sequence: !input down5Action
               - conditions:
                   - condition: state
                     entity_id: !input down_event
                     attribute: event_type
                     state: long_press
-                sequence: !input downHeld
+                sequence: !input downHeldAction
               - conditions:
                   - condition: state
                     entity_id: !input down_event
                     attribute: event_type
                     state: long_release
-                sequence: !input downReleased
+                sequence: !input downReleasedAction
       
       - conditions: # When the config button is the trigger.
           - condition: trigger
@@ -414,50 +414,48 @@ action:
                     entity_id: !input config_event
                     attribute: event_type
                     state: multi_press_1
-                sequence: !input config1
+                sequence: !input config1Action
               - conditions:
                   - condition: state
                     entity_id: !input config_event
                     attribute: event_type
                     state: multi_press_2
-                sequence: !input config2
+                sequence: !input config2Action
               - conditions:
                   - condition: state
                     entity_id: !input config_event
                     attribute: event_type
                     state: multi_press_3
-                sequence: !input config3
+                sequence: !input config3Action
               - conditions:
                   - condition: state
                     entity_id: !input config_event
                     attribute: event_type
                     state: multi_press_4
-                sequence: !input config4
+                sequence: !input config4Action
               - conditions:
                   - condition: state
                     entity_id: !input config_event
                     attribute: event_type
                     state: multi_press_5
-                sequence: !input config5
+                sequence: !input config5Action
               - conditions:
                   - condition: state
                     entity_id: !input config_event
                     attribute: event_type
                     state: long_press
-                sequence: !input configHeld
+                sequence: !input configHeldAction
               - conditions:
                   - condition: state
                     entity_id: !input config_event
                     attribute: event_type
                     state: long_release
-                sequence: !input configReleased
+                sequence: !input configReleasedAction
       
       - conditions:
           - condition: trigger
             id: turnOff
         sequence:
-          - variables:
-              controlLight: !input switch_light
           - action: light.turn_off
             metadata: {}
             data: {}
@@ -470,7 +468,7 @@ action:
               - reverseSyncOff
               - reverseSyncOn
         sequence:
-          - if: "{{ reverseSync }}"
+          - if: "{{ shouldSyncDefaultLightToSwitch }}"
             then:
               - choose:
                   - conditions:
@@ -495,12 +493,7 @@ action:
             id: turnOn
         sequence:
           - variables:
-              controlLight: !input switch_light
-              controlLightBrightness:
-                "{{ (state_attr(controlLight, 'brightness') / 2.55)
-                }}
-
-                "
+              switchLightBrightness: "{{ (state_attr(switchLight, 'brightness') / 2.55)}}"
               minBrightness: !input min_brightness
               brightnessValue:
                 "{{ (((100 - minBrightness) / 100 ) * controlLightBrightness

--- a/inovelli-matter-switch-tap-sequences.yaml
+++ b/inovelli-matter-switch-tap-sequences.yaml
@@ -1,7 +1,7 @@
 blueprint:
-  name: Inovelli Dev
+  name: Inovelli Matter Switch Tap Sequences
   description: |
-    ## Inovelli Dev
+    ## Inovelli Matter Switch Tap Sequences
 
     ### This blueprint will create an automation to:
 
@@ -30,8 +30,8 @@ blueprint:
   author: jay-kub
   homeassistant:
     min_version: 2024.8.0
-  input: # This section defines the inputs that appear visually for the user.
-    entity_inputs: # This section is for entities related to the switch itself.
+  input:
+    entity_inputs:
       name: Inovelli Switch Entities
       description:
         "Example: the Event Entity for Config can be found here: Settings > Devices & services > Matter > # Devices > *Select
@@ -48,7 +48,7 @@ blueprint:
                   domain: event
                   device_class: button
               multiple: false
-        down_event:
+        entity_down:
           name: Event Entity for Down
           description: The Event Entity for Down taps
           selector:
@@ -68,154 +68,154 @@ blueprint:
                   domain: event
                   device_class: button
               multiple: false
-        switch_light:
+        entity_light:
           name: Light Entity
           description: The light entity for the Inovelli Switch
           selector:
             entity:
               filter:
-                - domain: light
-                  integration: matter
+              - domain: light
+                integration: matter
               multiple: false
-    up_inputs: # This section lets the user define the actions when they press "up" n times.
+    up_inputs:
       name: Up
       icon: mdi:arrow-up-thick
       input:
-        up1Action:
+        up1:
           name: Single
           description: When Up is pressed 1 time
           default: []
           selector:
             action: {}
-        up2Action:
+        up2:
           name: Double
           description: When Up is pressed 2 times
           default: []
           selector:
             action: {}
-        up3Action:
+        up3:
           name: Triple
           description: When Up is pressed 3 times
           default: []
           selector:
             action: {}
-        up4Action:
+        up4:
           name: Quadruple
           description: When Up is pressed 4 times
           default: []
           selector:
             action: {}
-        up5Action:
+        up5:
           name: Quintuple
           description: When Up is pressed 5 times
           default: []
           selector:
             action: {}
-        upHeldAction:
+        upHeld:
           name: Up Held
           description: When Up is held
           default: []
           selector:
             action: {}
-        upReleasedAction:
+        upReleased:
           name: Up Released
           description: When Up is released
           default: []
           selector:
             action: {}
-    down_inputs: # This section defines the actions when the user presses down n times
+    down_inputs:
       name: Down
       icon: mdi:arrow-down-thick
       input:
-        down1Action:
+        down1:
           name: Single
           description: When Down is pressed 1 time
           default: []
           selector:
             action: {}
-        down2Action:
+        down2:
           name: Double
           description: When Down is pressed 2 times
           default: []
           selector:
             action: {}
-        down3Action:
+        down3:
           name: Triple
           description: When Down is pressed 3 times
           default: []
           selector:
             action: {}
-        down4Action:
+        down4:
           name: Quadruple
           description: When Down is pressed 4 times
           default: []
           selector:
             action: {}
-        down5Action:
+        down5:
           name: Quintuple
           description: When Down is pressed 5 times
           default: []
           selector:
             action: {}
-        downHeldAction:
+        downHeld:
           name: Down Held
           description: When Down is held
           default: []
           selector:
             action: {}
-        downReleasedAction:
+        downReleased:
           name: Down Released
           description: When Down is released
           default: []
           selector:
             action: {}
-    config_inputs: #This section defines the actions when the user presses config n times
+    config_inputs:
       name: Config
       icon: mdi:button-pointer
       input:
-        config1Action:
+        config1:
           name: Single
           description: When Config is pressed 1 time
           default: []
           selector:
             action: {}
-        config2Action:
+        config2:
           name: Double
           description: When Config is pressed 2 times
           default: []
           selector:
             action: {}
-        config3Action:
+        config3:
           name: Triple
           description: When Config is pressed 3 times
           default: []
           selector:
             action: {}
-        config4Action:
+        config4:
           name: Quadruple
           description: When Config is pressed 4 times
           default: []
           selector:
             action: {}
-        config5Action:
+        config5:
           name: Quintuple
           description: When Config is pressed 5 times
           default: []
           selector:
             action: {}
-        configHeldAction:
+        configHeld:
           name: Config Held
           description: When Config is held
           default: []
           selector:
             action: {}
-        configReleasedAction:
+        configReleased:
           name: Config Released
           description: When Config is released
           default: []
           selector:
             action: {}
-    binding_inputs: # This section defines entities and settings that are bound virtually to the switch
+    binding_inputs:
       name: Light Bindings
       icon: mdi:sync
       input:
@@ -262,55 +262,48 @@ trigger:
   - platform: state
     entity_id: !input entity_up
     not_from:
-      - unknown
-      - unavailable
-
-  - id: down
-    platform: state
-    entity_id: !input down_event
-    not_from:
-      - unknown
-      - unavailable
-
-  - id: config
-    platform: state
-    entity_id: !input config_event
-    not_from:
-      - unknown
-      - unavailable
-
-  - id: turnOn
-    platform: state
-    entity_id: !input switch_light
-    from: "off"
-    to: "on"
-
-  - id: turnOff
-    platform: state
-    entity_id: !input switch_light
-    from: "on"
-    to: "off"
-
-  - id: reverseSyncOff
-    platform: state
-    entity_id: !input default_light
-    from: "on"
-    to: "off"
-
-  - id: reverseSyncOn
-    platform: state
-    entity_id: !input default_light
-    from: "off"
-    to: "on"
-    
+    - unknown
+    - unavailable
+    id: up
   - platform: state
-    entity_id: !input switch_light
+    entity_id: !input entity_down
+    not_from:
+    - unknown
+    - unavailable
+    id: down
+  - platform: state
+    entity_id: !input entity_config
+    not_from:
+    - unknown
+    - unavailable
+    id: config
+  - platform: state
+    entity_id: !input entity_light
+    id: turnOn
+    from: "off"
+    to: "on"
+  - platform: state
+    entity_id: !input entity_light
+    id: turnOff
+    from: "on"
+    to: "off"
+  - platform: state
+    entity_id: !input target_light
+    id: reverseSyncOff
+    from: "on"
+    to: "off"
+  - platform: state
+    entity_id: !input target_light
+    id: reverseSyncOn
+    from: "off"
+    to: "on"
+  - platform: state
+    entity_id: !input entity_light
     attribute: brightness
     id: turnOn
 
 condition: []
 
-# The automation itself. When triggered, this is the main script that will run.
 action:
 - choose:
   - conditions:

--- a/inovelli-matter-switch-tap-sequences.yaml
+++ b/inovelli-matter-switch-tap-sequences.yaml
@@ -37,9 +37,9 @@ blueprint:
         your device* > Events > Up > Settings Icon > entity_id"
       icon: mdi:devices
       input:
-        config_event:
-          name: Event Entity for Config
-          description: The event entity for Config taps
+        up_event:
+          name: Event Entity for Up
+          description: The Event Entity for Up taps*
           selector:
             entity:
               filter:
@@ -57,9 +57,9 @@ blueprint:
                   domain: event
                   device_class: button
               multiple: false
-        up_event:
-          name: Event Entity for Up
-          description: The Event Entity for Up taps*
+        config_event:
+          name: Event Entity for Config
+          description: The event entity for Config taps
           selector:
             entity:
               filter:

--- a/inovelli-matter-switch-tap-sequences.yaml
+++ b/inovelli-matter-switch-tap-sequences.yaml
@@ -30,8 +30,9 @@ blueprint:
   author: jay-kub
   homeassistant:
     min_version: 2024.8.0
-  input:
-    entity_inputs:
+
+  input: # This section defines the inputs that appear visually for the user.
+    entity_inputs: # This section is for entities related to the switch itself.
       name: Inovelli Switch Entities
       description:
         "Example: the Event Entity for Config can be found here: Settings > Devices & services > Matter > # Devices > *Select
@@ -77,7 +78,7 @@ blueprint:
               - domain: light
                 integration: matter
               multiple: false
-    up_inputs:
+    up_inputs: # This section lets the user define the actions when they press "up" n times.
       name: Up
       icon: mdi:arrow-up-thick
       input:
@@ -123,7 +124,7 @@ blueprint:
           default: []
           selector:
             action: {}
-    down_inputs:
+    down_inputs: # This section defines the actions when the user presses down n times
       name: Down
       icon: mdi:arrow-down-thick
       input:
@@ -169,7 +170,7 @@ blueprint:
           default: []
           selector:
             action: {}
-    config_inputs:
+    config_inputs:  # This section defines the actions when the user presses config n times
       name: Config
       icon: mdi:button-pointer
       input:
@@ -215,7 +216,7 @@ blueprint:
           default: []
           selector:
             action: {}
-    binding_inputs:
+    binding_inputs: # This section defines entities and settings that are bound virtually to the switch
       name: Light Bindings
       icon: mdi:sync
       input:
@@ -253,12 +254,16 @@ blueprint:
           selector:
             boolean: {}
   source_url: https://github.com/jay-kub/inovelli-matter-switch-tap-sequences/blob/dev/inovelli-matter-switch-tap-sequences.yaml
+# End Blueprint definition
+
+# Start Automation definition
 mode: queued
 max_exceeded: silent
-variables:
+
+variables:  # Set up variables to be used in templates.
   reverseSync: !input reverse_sync
 
-trigger:
+trigger: # Defines the triggers the automation will use to run. Nominally the events from the switch.
   - platform: state
     entity_id: !input entity_up
     not_from:
@@ -304,13 +309,12 @@ trigger:
 
 condition: []
 
-action:
+action: # The automation itself. When triggered, this is the main script that will run.
 - choose:
-  - conditions:
+  - conditions: # When the up event is the trigger
     - condition: trigger
-      id:
-      - up
-    sequence:
+      id: up
+    sequence: # Check the state of the up event based on number of clicks.
     - choose:
       - conditions:
         - condition: state
@@ -354,11 +358,11 @@ action:
           attribute: event_type
           state: long_release
         sequence: !input upReleased
-  - conditions:
+
+  - conditions: # When the down button is the trigger.
     - condition: trigger
-      id:
-      - down
-    sequence:
+      id: down
+    sequence: # Check the state of the down event based on number of clicks.
     - choose:
       - conditions:
         - condition: state
@@ -402,11 +406,11 @@ action:
           attribute: event_type
           state: long_release
         sequence: !input downReleased
-  - conditions:
+
+  - conditions: # When the config button is the trigger.
     - condition: trigger
-      id:
-      - config
-    sequence:
+      id: config
+    sequence: # Check the state of the config event based on number of clicks.
     - choose:
       - conditions:
         - condition: state

--- a/inovelli-matter-switch-tap-sequences.yaml
+++ b/inovelli-matter-switch-tap-sequences.yaml
@@ -53,10 +53,8 @@ blueprint:
             entity:
               filter:
               - integration: matter
-                domain:
-                - event
-                device_class:
-                - button
+                domain: event
+                device_class: button
               multiple: false
         entity_up:
           name: Event Entity for Up
@@ -65,10 +63,8 @@ blueprint:
             entity:
               filter:
               - integration: matter
-                domain:
-                - event
-                device_class:
-                - button
+                domain: event
+                device_class: button
               multiple: false
         entity_light:
           name: Light Entity
@@ -76,8 +72,8 @@ blueprint:
           selector:
             entity:
               filter:
-              - domain:
-                - light
+              - domain: light
+                integration: matter
               multiple: false
     up_inputs:
       name: Up


### PR DESCRIPTION
1. Updated icons to use up and down arrows and a button icon for the config section. More visually distinct.
2. changed tag names. entity_up --> up_event and so on. entity_light has been renamed default_light to make it's purpose more clear. 
3. Filter clean up. Since only one filter per type was used a list was not necessary. Removed lists and replaced with single line filters.
4. For default light, changed multiple from true to false. Users should likely use a group light here. Tracking individual lights and their changes could get tricky otherwise.