### PR TITLE
Bugfix: added config button check to fan sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@
 - VTM35-SN (White Fan Switch)
 - VTM36 (White Fan/Light Canopy Module)
 #### Version 0.3.3 (11/13/2025)
-Bugfix: Bugfix: added config button check to fan sync
+Bugfix: added config button check to fan sync

--- a/README.md
+++ b/README.md
@@ -16,10 +16,5 @@
 - VTM31-SN (White Dimmer Switch)
 - VTM35-SN (White Fan Switch)
 - VTM36 (White Fan/Light Canopy Module)
-
-#### Version 0.3.3 (11/12/2025)
+#### Version 0.3.3 (11/13/2025)
 Bugfix: Bugfix: added config button check to fan sync
-
-#### Version 0.3.2 (10/15/2025)
-Bugfix: light binding now works with VTM30-SN (tip: use the 'Show as' feature to create a light entity and disable Brightness Sync)
-Bugfix: remove matter integration filter from Inovelli Switch Light 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - VTM36 (White Fan/Light Canopy Module)
 
 #### Version 0.3.3 (11/12/2025)
-Bugfix: Added config button checks to fan conditions so up press no longer causes the fan to turn on when native Matter binding is enabled between the VTM31-SN dimmer and VTM36 light endpoints (tip: light binding in this blueprint is still recommended for Python Matter Server since virtual toggles do not seem to trigger native binding. This should eventually be fixed with the move to matter.js. Native binding just offers more responsive light control at the physical switch)
+Bugfix: Bugfix: added config button check to fan sync
 
 #### Version 0.3.2 (10/15/2025)
 Bugfix: light binding now works with VTM30-SN (tip: use the 'Show as' feature to create a light entity and disable Brightness Sync)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - VTM36 (White Fan/Light Canopy Module)
 
 #### Version 0.3.3 (11/12/2025)
-Bugfix: Added config button checks to fan conditions so up press no longer causes the fan to turn on when native Matter binding is enabled between the VTM31-SN dimmer and VTM36 light endpoints
+Bugfix: Added config button checks to fan conditions so up press no longer causes the fan to turn on when native Matter binding is enabled between the VTM31-SN dimmer and VTM36 light endpoints (tip: light binding in this blueprint is still recommended for Python Matter Server since virtual toggles do not seem to trigger native binding. This should eventually be fixed with the move to matter.js. Native binding just offers more responsive light control at the physical switch)
 
 #### Version 0.3.2 (10/15/2025)
 Bugfix: light binding now works with VTM30-SN (tip: use the 'Show as' feature to create a light entity and disable Brightness Sync)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 - VTM31-SN (White Dimmer Switch)
 - VTM35-SN (White Fan Switch)
 - VTM36 (White Fan/Light Canopy Module)
+
+#### Version 0.3.3 (11/12/2025)
+Bugfix: Added config button checks to fan conditions so up press no longer causes the fan to turn on when native Matter binding is enabled between the VTM31-SN dimmer and VTM36 light endpoints
+
 #### Version 0.3.2 (10/15/2025)
 Bugfix: light binding now works with VTM30-SN (tip: use the 'Show as' feature to create a light entity and disable Brightness Sync)
 Bugfix: remove matter integration filter from Inovelli Switch Light 

--- a/inovelli-matter-switch-tap-sequences.yaml
+++ b/inovelli-matter-switch-tap-sequences.yaml
@@ -32,7 +32,7 @@ blueprint:
     Go to https://github.com/jay-kub/inovelli-matter-switch-tap-sequences to report issues or request new features.
 
     #### Version 0.3.3 (11/12/2025)
-    Bugfix: Added config button checks to fan conditions so up press no longer causes the fan to turn on when native Matter binding is enabled between the VTM31-SN dimmer and VTM36 light endpoints (tip: light binding in this blueprint is still recommended for Python Matter Server since virtual toggles do not seem to trigger native binding. This should eventually be fixed with the move to matter.js. Native binding just offers more responsive light control at the physical switch)
+    Bugfix: Bugfix: added config button check to fan sync
 
     Version 0.3.2 (10/15/2025)
     Bugfix: light binding now works with VTM30-SN (tip: use the 'Show as' feature to create a light entity and disable Brightness Sync)
@@ -556,7 +556,12 @@ action:
             brightness_pct: '{{ targetBrightnessPct }}'
           target:
             entity_id: !input target_light
-- if: '{{ targetFan != [] }}'
+- if: 
+  - condition: template
+    value_template: '{{ targetFan != [] }}'
+  - condition: trigger
+    id:
+      - config
   then:
     - choose:
       - conditions:
@@ -564,7 +569,6 @@ action:
           id:
             - config
         - condition: state
-          entity_id: !input entity_config
           attribute: event_type
           state: multi_press_1
         sequence:
@@ -578,7 +582,6 @@ action:
           id:
             - config
         - condition: state
-          entity_id: !input entity_config
           attribute: event_type
           state: multi_press_2
         sequence:
@@ -592,7 +595,6 @@ action:
           id:
             - config
         - condition: state
-          entity_id: !input entity_config
           attribute: event_type
           state: multi_press_3
         sequence:
@@ -606,7 +608,6 @@ action:
           id:
             - config
         - condition: state
-          entity_id: !input entity_config
           attribute: event_type
           state: long_press
         sequence:

--- a/inovelli-matter-switch-tap-sequences.yaml
+++ b/inovelli-matter-switch-tap-sequences.yaml
@@ -31,6 +31,9 @@ blueprint:
 
     Go to https://github.com/jay-kub/inovelli-matter-switch-tap-sequences to report issues or request new features.
 
+    #### Version 0.3.3 (11/12/2025)
+    Bugfix: Added config button checks to fan conditions so up press no longer causes the fan to turn on when native Matter binding is enabled between the VTM31-SN dimmer and VTM36 light endpoints (tip: light binding in this blueprint is still recommended for Python Matter Server since virtual toggles do not seem to trigger native binding. This should eventually be fixed with the move to matter.js. Native binding just offers more responsive light control at the physical switch)
+
     Version 0.3.2 (10/15/2025)
     Bugfix: light binding now works with VTM30-SN (tip: use the 'Show as' feature to create a light entity and disable Brightness Sync)
     Bugfix: remove matter integration filter from Inovelli Switch Light 

--- a/inovelli-matter-switch-tap-sequences.yaml
+++ b/inovelli-matter-switch-tap-sequences.yaml
@@ -31,12 +31,8 @@ blueprint:
 
     Go to https://github.com/jay-kub/inovelli-matter-switch-tap-sequences to report issues or request new features.
 
-    #### Version 0.3.3 (11/12/2025)
+    #### Version 0.3.3 (11/13/2025)
     Bugfix: added config button check to fan sync
-
-    Version 0.3.2 (10/15/2025)
-    Bugfix: light binding now works with VTM30-SN (tip: use the 'Show as' feature to create a light entity and disable Brightness Sync)
-    Bugfix: remove matter integration filter from Inovelli Switch Light 
   domain: automation
   author: jay-kub
   homeassistant:

--- a/inovelli-matter-switch-tap-sequences.yaml
+++ b/inovelli-matter-switch-tap-sequences.yaml
@@ -31,7 +31,7 @@ blueprint:
 
     Go to https://github.com/jay-kub/inovelli-matter-switch-tap-sequences to report issues or request new features.
 
-    Version 0.3.3 (11/12/2025)
+    #### Version 0.3.3 (11/12/2025)
     Bugfix: added config button check to fan sync
 
     Version 0.3.2 (10/15/2025)

--- a/inovelli-matter-switch-tap-sequences.yaml
+++ b/inovelli-matter-switch-tap-sequences.yaml
@@ -31,8 +31,8 @@ blueprint:
 
     Go to https://github.com/jay-kub/inovelli-matter-switch-tap-sequences to report issues or request new features.
 
-    #### Version 0.3.3 (11/12/2025)
-    Bugfix: Bugfix: added config button check to fan sync
+    Version 0.3.3 (11/12/2025)
+    Bugfix: added config button check to fan sync
 
     Version 0.3.2 (10/15/2025)
     Bugfix: light binding now works with VTM30-SN (tip: use the 'Show as' feature to create a light entity and disable Brightness Sync)
@@ -556,19 +556,17 @@ action:
             brightness_pct: '{{ targetBrightnessPct }}'
           target:
             entity_id: !input target_light
-- if: 
+- if:
   - condition: template
-    value_template: '{{ targetFan != [] }}'
+    value_template: "{{ targetFan != [] }}"
   - condition: trigger
     id:
       - config
   then:
     - choose:
       - conditions:
-        - condition: trigger
-          id:
-            - config
         - condition: state
+          entity_id: !input entity_config
           attribute: event_type
           state: multi_press_1
         sequence:
@@ -578,10 +576,8 @@ action:
           target:
            entity_id: !input target_fan
       - conditions:
-        - condition: trigger
-          id:
-            - config
         - condition: state
+          entity_id: !input entity_config
           attribute: event_type
           state: multi_press_2
         sequence:
@@ -591,10 +587,8 @@ action:
           target:
            entity_id: !input target_fan
       - conditions:
-        - condition: trigger
-          id:
-            - config
         - condition: state
+          entity_id: !input entity_config
           attribute: event_type
           state: multi_press_3
         sequence:
@@ -604,10 +598,8 @@ action:
           target:
            entity_id: !input target_fan
       - conditions:
-        - condition: trigger
-          id:
-            - config
         - condition: state
+          entity_id: !input entity_config
           attribute: event_type
           state: long_press
         sequence:

--- a/inovelli-matter-switch-tap-sequences.yaml
+++ b/inovelli-matter-switch-tap-sequences.yaml
@@ -557,6 +557,9 @@ action:
   then:
     - choose:
       - conditions:
+        - condition: trigger
+          id:
+            - config
         - condition: state
           entity_id: !input entity_config
           attribute: event_type
@@ -568,6 +571,9 @@ action:
           target:
            entity_id: !input target_fan
       - conditions:
+        - condition: trigger
+          id:
+            - config
         - condition: state
           entity_id: !input entity_config
           attribute: event_type
@@ -579,6 +585,9 @@ action:
           target:
            entity_id: !input target_fan
       - conditions:
+        - condition: trigger
+          id:
+            - config
         - condition: state
           entity_id: !input entity_config
           attribute: event_type
@@ -590,6 +599,9 @@ action:
           target:
            entity_id: !input target_fan
       - conditions:
+        - condition: trigger
+          id:
+            - config
         - condition: state
           entity_id: !input entity_config
           attribute: event_type


### PR DESCRIPTION
I turned on binding in Python Matter Server for the dimmer switch -> light endpoints in my VTM31-SN and VTM36 and noticed a peculiar behavior. If you press up on the switch to turn on the light, it also turns on the fan. This occurs regardless of whether light binding is mapped in the automation. This PR fixes it at least for me.

As much as I would like to go 100% in on native binding rather than an automation, I don't see an easy way to map the config button to the fan endpoint in binding. Plus, it seems like native binding currently only works when the button is physically pressed, not when it is toggled inside Home Assistant. On the flip side, light controls are more responsive using native binding and should work even when Home Assistant is offline/rebooting, so it seems like the current best solution is to run both together.